### PR TITLE
Add planet hit counter with API integration AWS

### DIFF
--- a/js/counter/planetHitCounter.js
+++ b/js/counter/planetHitCounter.js
@@ -1,0 +1,79 @@
+export default class HitCounter {
+    /**
+     * @param {Phaser.Scene} scene - Die aktuelle Phaser-Szene
+     * @param {number} x - X-Koordinate für den Text
+     * @param {number} y - Y-Koordinate für den Text
+     * @param {string} api_url - Die API Gateway Aufruf-URL
+     */
+    constructor(scene, x, y, api_url) {
+        // **WICHTIG:** Ersetze diesen Platzhalter durch deine tatsächliche API Gateway URL!
+        this.API_URL = api_url;
+
+        // Erstelle das Phaser Text-Objekt
+        this.counterText = scene.add.text(x, y, 'Lade Zähler...', {
+            fontSize: '32px',
+            fill: '#ffffff',
+            fontFamily: 'PokemonG3'
+        });
+
+        // Starte die Zählerlogik sofort, wenn die Klasse instanziiert wird
+        this.incrementAndDisplay();
+    }
+
+    /**
+     * 1. Ruft den aktuellen Zählerstand über GET ab und zeigt ihn an.
+     * (Wird in diesem Setup nur zur Initialisierung oder Fehlerbehebung benötigt,
+     * da POST den neuen Wert zurückgibt.)
+     */
+    async getCount() {
+        try {
+            const response = await fetch(this.API_URL, { method: 'GET' });
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+
+            const dataRAW = await response.json();
+            const data = JSON.parse(dataRAW.body);
+            const currentCount = data.currentCount;
+
+            this.counterText.setText(`${currentCount}`);
+            return currentCount;
+
+        } catch (error) {
+            console.error('Fehler beim Abrufen des Zählers:', error);
+            this.counterText.setText('Fehler');
+        }
+    }
+
+    /**
+     * 2. Inkrementiert den Zählerstand über POST und aktualisiert die Anzeige.
+     */
+    async incrementAndDisplay() {
+        try {
+            this.counterText.setText('Zähle...');
+
+            const response = await fetch(this.API_URL, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({})
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+
+            const dataRAW = await response.json();
+            const data = JSON.parse(dataRAW.body);
+            const newCount = data.newCount;
+
+            // Aktualisiere das Phaser Text-Objekt mit dem neuen Wert
+            this.counterText.setText(`${newCount}`);
+
+        } catch (error) {
+            console.error('Fehler beim Inkrementieren des Zählers:', error);
+            this.counterText.setText('Zähl-Fehler!');
+        }
+    }
+}

--- a/js/scenes/start.js
+++ b/js/scenes/start.js
@@ -1,11 +1,15 @@
 import {gW, gH} from "../../main.js";
 import {textbox} from "../util/iHandleTextbox.js";
 import {rngPoint} from "../rng/randomPoint.js";
+import HitCounter from "../counter/planetHitCounter.js";
+
+const COUNTER_API_URL = "https://r44pno55t2.execute-api.eu-central-1.amazonaws.com/api/counter";
 
 export class Start extends Phaser.Scene
 {
     constructor() {
         super({ key: 'Start' });
+        this.hitCounter = null;
     }
 
     preload ()
@@ -31,6 +35,20 @@ export class Start extends Phaser.Scene
             scale: { start: (gW/300), end: 0 },
             blendMode: 'ADD'
         });
+        // Planet Hit Counter
+        this.add.text(gW/10, gH/12, "Planet Hits:", {
+            fontSize: '24px',
+            fill: '#ffffff',
+            fontFamily: 'PokemonG3'
+        });//,
+
+        this.hitCounter = new HitCounter(
+            this,                 // Die aktuelle Szene
+            gW/10,                   // X-Koordinate (z.B. links oben)
+            gH/10,                   // Y-Koordinate
+            COUNTER_API_URL       // Deine API URL
+        );
+
         //Logo
         const logo = this.physics.add.image(rngPoint(gW,gH).x, rngPoint(gW,gH).y, 'logo');
         logo.displayWidth = gW/3;
@@ -43,7 +61,7 @@ export class Start extends Phaser.Scene
 
         logo.setInteractive();
         logo.on('pointerdown', () => {
-            this.scene.start('Menu');
+            this.hitCounter.incrementAndDisplay();
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@
 }
 
 :root{
-    font-family:"PokemonG1", system-ui, "Arial Black", Webdings, sans-serif;
+    font-family:"PokemonG1", "PokemonG3", "Arial Black", Webdings, sans-serif;
     --dClr:#181818;
     --lClr:whitesmoke;
     --aClr:#0D0D35;


### PR DESCRIPTION
Introduced a new HitCounter class to display and increment a planet hit counter using a remote API. Integrated the counter into the Start scene, displaying the current count and updating it on logo click. Also updated the font stack in styles.css to include 'PokemonG3' for improved font rendering.