### PR TITLE
LOGO BOUNCE: Adjust logo scaling and hit counter logic on start scene

### DIFF
--- a/js/counter/planetHitCounter.js
+++ b/js/counter/planetHitCounter.js
@@ -17,7 +17,7 @@ export default class HitCounter {
         });
 
         // Starte die Zählerlogik sofort, wenn die Klasse instanziiert wird
-        this.incrementAndDisplay();
+        this.getCount();
     }
 
     /**

--- a/js/scenes/start.js
+++ b/js/scenes/start.js
@@ -27,20 +27,23 @@ export class Start extends Phaser.Scene
         const sky = this.add.image(gW/2, gH/1.5, 'sky');
         sky.displayWidth = gW;
         sky.displayHeight = gH/2;
+
         //Textbox
         textbox(this, "PRESS THE PLANET");
+
         //Partikel
         const particles = this.add.particles(0, 0, 'blue', {
             speed: gH/5,
-            scale: { start: (gW/300), end: 0 },
+            scale: { start: (gW/450), end: 0 },
             blendMode: 'ADD'
         });
+
         // Planet Hit Counter
         this.add.text(gW/10, gH/12, "Planet Hits:", {
             fontSize: '24px',
             fill: '#ffffff',
             fontFamily: 'PokemonG3'
-        });//,
+        });
 
         this.hitCounter = new HitCounter(
             this,                 // Die aktuelle Szene
@@ -51,9 +54,11 @@ export class Start extends Phaser.Scene
 
         //Logo
         const logo = this.physics.add.image(rngPoint(gW,gH).x, rngPoint(gW,gH).y, 'logo');
-        logo.displayWidth = gW/3;
-        logo.displayHeight = gW/3;
-        logo.setVelocity(50, 100);
+        logo.displayWidth = gW/4;
+        logo.displayHeight = gW/4;
+        let speedX = 50;
+        let speedY = 100;
+        logo.setVelocity(speedX, speedY);
         logo.setBounce(1, 1);
         logo.setCollideWorldBounds(true);
 
@@ -62,6 +67,12 @@ export class Start extends Phaser.Scene
         logo.setInteractive();
         logo.on('pointerdown', () => {
             this.hitCounter.incrementAndDisplay();
+            let rndPoint = rngPoint(gW,gH);
+            logo.x = rndPoint.x;
+            logo.y = rndPoint.y;
+            speedX = speedX * 1.1;
+            speedY = speedY * 1.1;
+            logo.setVelocity(speedX, speedY);
         });
     }
 


### PR DESCRIPTION
Changed the logo's display size and velocity scaling in the start scene. Updated the hit counter initialization to call getCount() instead of incrementAndDisplay(). On logo click, the logo now moves to a random position and increases its speed, enhancing interactivity.