### PR TITLE
Fix background image path in preload method

### DIFF
--- a/js/util/iHandleBackground.js
+++ b/js/util/iHandleBackground.js
@@ -9,7 +9,7 @@ export default class BackgroundHandler{
     preload(){
         let key = this.scene.scene.key;
         console.log("--- Loading background:", key);
-        this.scene.load.image('bg-img',`../../assets/backgrounds/${key}.png`);
+        this.scene.load.image('bg-img',`../assets/backgrounds/${key}.png`);
     }
 
     create(){


### PR DESCRIPTION
Updated the image path in the preload method to correctly reference the backgrounds directory. This resolves issues with loading background images due to an incorrect relative path.