### PR TITLE
Remove leading slash from background image path

### DIFF
--- a/js/util/iHandleBackground.js
+++ b/js/util/iHandleBackground.js
@@ -9,7 +9,7 @@ export default class BackgroundHandler{
     preload(){
         let key = this.scene.scene.key;
         console.log("--- Loading background:", key);
-        this.scene.load.image('bg-img',`/assets/backgrounds/${key}.png`);
+        this.scene.load.image('bg-img',`assets/backgrounds/${key}.png`);
     }
 
     create(){


### PR DESCRIPTION
Updated the image path in BackgroundHandler to remove the leading slash, ensuring compatibility with relative asset loading.