### PR TITLE
Adjust position of speed display text

### DIFF
--- a/gameobjects/start/game-Start.js
+++ b/gameobjects/start/game-Start.js
@@ -48,8 +48,8 @@ export default class gameStart {
         logo.setCollideWorldBounds(true);
         particles.startFollow(logo);
 
-        // Speed-Anzeige vorbereiten
-        this.speedText = this.scene.add.text(gW*0.9, gH/10, "Speed: 0", {
+        // Speed-Anzeige
+        this.speedText = this.scene.add.text(gW*0.8, gH/10, "Speed: 0", {
             fontSize: '24px',
             fill: '#ffffff',
             fontFamily: 'PokemonG3'


### PR DESCRIPTION
Moved the speed display text from 90% to 80% of the game width for better alignment or visibility.