### PR TITLE
Adjust speed text poition for mobile

### DIFF
--- a/gameobjects/start/game-Start.js
+++ b/gameobjects/start/game-Start.js
@@ -49,7 +49,7 @@ export default class gameStart {
         particles.startFollow(logo);
 
         // Speed-Anzeige
-        this.speedText = this.scene.add.text(gW*0.8, gH/10, "Speed: 0", {
+        this.speedText = this.scene.add.text(gW*0.7, gH/10, "Speed: 0", {
             fontSize: '24px',
             fill: '#ffffff',
             fontFamily: 'PokemonG3'


### PR DESCRIPTION
Moved the speed display text from 80% to 70% of the game width to improve layout on the start screen.